### PR TITLE
Multithreaded chunk unload for both unloading and render distance "stuff"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/Release_Builds/*
+/.mono/*
+/.vs/*
+/.import/*

--- a/Chunk.gd
+++ b/Chunk.gd
@@ -1,13 +1,13 @@
 extends StaticBody
 
-const DIMENSION = Vector3(20,50,20)
+const DIMENSION = Vector3(10,10,10)
 
 var mat = preload("res://assets/TextureAtlasMaterial.tres")
 var rng = RandomNumberGenerator.new()
 # Make this load from a file
 const texture_atlas_size = Vector2(8, 4)
 
-var generator = load("res://chunk_generators/ForestGenerator.gd")
+var generator = load("res://chunk_generators/BaseGenerator.gd")
 
 const v = [
 	Vector3(0, 0, 0), #0

--- a/Chunk.gd
+++ b/Chunk.gd
@@ -1,13 +1,13 @@
 extends StaticBody
 
-const DIMENSION = Vector3(10,10,10)
+const DIMENSION = Vector3(16,50,16)
 
 var mat = preload("res://assets/TextureAtlasMaterial.tres")
 var rng = RandomNumberGenerator.new()
 # Make this load from a file
 const texture_atlas_size = Vector2(8, 4)
 
-var generator = load("res://chunk_generators/BaseGenerator.gd")
+var generator = load("res://chunk_generators/ForestGenerator.gd")
 
 const v = [
 	Vector3(0, 0, 0), #0

--- a/ProcWorld.gd
+++ b/ProcWorld.gd
@@ -95,7 +95,9 @@ func _load_chunk(cx, cz):
 		c.generate(self, cx, cz)
 		c.update()
 		add_child(c)
+		chunk_mutex.lock()
 		_loaded_chunks[c_pos] = c
+		chunk_mutex.unlock()
 	return c_pos
 
 func _update_chunk(cx, cz):

--- a/ProcWorld.gd
+++ b/ProcWorld.gd
@@ -3,11 +3,14 @@ var height_noise = OpenSimplexNoise.new()
 
 onready var Chunk = load("res://Chunk.gd")
 
-# Thread variables
-var thread
-var mutex
-var semaphore
-var kill_thread = false
+# Thread variables No reason to declare these on startup just do it up here
+var thread = Thread.new()
+var mutex = Mutex.new()
+var semaphore = Semaphore.new()
+var bKill_thread = false
+
+#Use this when adding/removing from the chunk array/dict
+var chunk_mutex = Mutex.new()
 
 var _new_chunk_pos = Vector2()
 var _chunk_pos = null
@@ -20,17 +23,14 @@ var _kill_thread = false
 const load_radius = 5
 var current_load_radius = 0
 
-func _ready():
-	thread = Thread.new()
-	mutex = Mutex.new()
-	semaphore = Semaphore.new()
-	
+func _ready():	
 	thread.start(self, "_thread_gen")
 	height_noise.period = 100
 
+
 func _thread_gen(userdata):
 	# Center map generation on the player
-	while(!kill_thread):
+	while(!bKill_thread):
 		# Check if player in new chunk
 		var player_pos_updated = false
 
@@ -40,8 +40,6 @@ func _thread_gen(userdata):
 		var current_chunk_pos = Vector2(_new_chunk_pos.x, _new_chunk_pos.y)
 		
 		if player_pos_updated:
-			print("updated player pos")
-			print(current_load_radius)
 			# If new chunk unload unneeded chunks (changed to be entirely done off main thread if I understand correctly, fixling some stuttering I was feeling
 			enforce_render_distance(current_chunk_pos)
 			# Make sure player chunk is loaded
@@ -96,8 +94,10 @@ func _load_chunk(cx, cz):
 		var c = Chunk.new()
 		c.generate(self, cx, cz)
 		c.update()
-		call_deferred("add_child", c)
+		add_child(c)
+		chunk_mutex.lock()
 		_loaded_chunks[c_pos] = c
+		chunk_mutex.unlock()
 	return c_pos
 
 func _update_chunk(cx, cz):
@@ -118,8 +118,10 @@ func enforce_render_distance(current_chunk_pos):
 		for v in _loaded_chunks.keys():
 			# Anywhere you directly interface with chunks outside of unloading
 			if abs(v.x - current_chunk_pos.x) > load_radius or abs(v.y - current_chunk_pos.y) > load_radius:
+				chunk_mutex.lock()
 				_loaded_chunks[v].free()
 				_loaded_chunks.erase(v)
+				chunk_mutex.unlock()
 				chunks_removed+=1
 	print(chunks_removed)
 
@@ -127,11 +129,13 @@ func enforce_render_distance(current_chunk_pos):
 func _unload_chunk(cx, cz):
 	var c_pos = Vector2(cx, cz)
 	if _loaded_chunks.has(c_pos):
+		chunk_mutex.lock()
 		_loaded_chunks[c_pos].free()
 		_loaded_chunks.erase(c_pos)
+		chunk_mutex.unlock()
 		# Leaving this here because it is funny as hell
 		# Force it to just fucking chill after holy shit
 		# OS.delay_msec(50)
 
 func kill_thread():
-	kill_thread = true
+	bKill_thread = true

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -27,7 +27,7 @@ size = Vector3( 1.01, 1.01, 1.01 )
 script = ExtResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6.05201, 58.3962, -0.374958 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.18661, 47.174, 0 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource( 2 )

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -27,7 +27,7 @@ size = Vector3( 1.01, 1.01, 1.01 )
 script = ExtResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 73.711, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6.05201, 58.3962, -0.374958 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource( 2 )

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -27,7 +27,7 @@ size = Vector3( 1.01, 1.01, 1.01 )
 script = ExtResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.18661, 47.174, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 55.5835, 47.174, 0 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource( 2 )

--- a/WorldScript.gd
+++ b/WorldScript.gd
@@ -5,6 +5,9 @@ var pw
 onready var player = $Player
 onready var block_outline = $BlockOutline
 
+var chunk_x = 1
+var chunk_z = 1
+
 var Chunk = load("res://Chunk.gd")
 var ProcWorld = load("res://ProcWorld.gd")
 

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,42 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="Release_Builds/TestBuild.exe"
+patch_list=PoolStringArray(  )
+script_export_mode=1
+script_encryption_key=""
+
+[preset.0.options]
+
+texture_format/bptc=false
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+texture_format/no_bptc_fallbacks=true
+binary_format/64_bits=true
+binary_format/embed_pck=false
+custom_template/release=""
+custom_template/debug=""
+codesign/enable=false
+codesign/identity_type=0
+codesign/identity=""
+codesign/password=""
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PoolStringArray(  )
+application/icon=""
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""

--- a/pic.PNG.import
+++ b/pic.PNG.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/pic.PNG-6539c44f86b77cbed2a67dfe4c7a9606.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://pic.PNG"
+dest_files=[ "res://.import/pic.PNG-6539c44f86b77cbed2a67dfe4c7a9606.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=false
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0


### PR DESCRIPTION
Note: I have not really touched chunk generation with the exception of increasing the load radius to 5 and the chunk width and length to 16 for testing purposes. Chunk loading speed is about the same, though you do not have large lag spikes walking in and out of chunks. It also *might* help with block placement a little bit, but not much if at all, at least I am not seeing an improvement. 

I have experienced one or two crashes and odd spikes of chunk unloading, that being said those have been fairly rare. I am tracking down what causes the former currently. I am also unsure if that crash was due to something that was not mine.

I have placed a mutex on everything that handles the "loaded_chunks" array? dictionary? not sure what it is, I think it is a multi-dimensional array but it does not look like it at the same time. (the problem with dynamically typed languages without great IDE's that you cannot tell what the variable is unless you are in the mindset of the person who made it) grabbing the chunk itself and manipulating it is not mutexed and I would expect that to be handled in the chunk itself if it was a huge concern.