### PR TITLE
Limit terrain gen height and add offset

### DIFF
--- a/Chunk.gd
+++ b/Chunk.gd
@@ -4,7 +4,7 @@ const DIMENSION = Vector3(16,50,16)
 
 # Ensures terrain gen does not elongate based on chunk size/resolution so terrain at a chunk 30 blocks tall still looks the same as a 50 block tall chunk
 # It ensures structures and trees have the ability to grow should 
-const Gen_Height = 30
+const Gen_Height = 50
 
 # Moves terrain height up and down chunk 
 # NOTE: this is applied after the gen height calculation, that means it will affect the final output of Gen_Height

--- a/Chunk.gd
+++ b/Chunk.gd
@@ -2,6 +2,14 @@ extends StaticBody
 
 const DIMENSION = Vector3(16,50,16)
 
+# Ensures terrain gen does not elongate based on chunk size/resolution so terrain at a chunk 30 blocks tall still looks the same as a 50 block tall chunk
+# It ensures structures and trees have the ability to grow should 
+const Gen_Height = 30
+
+# Moves terrain height up and down chunk 
+# NOTE: this is applied after the gen height calculation, that means it will affect the final output of Gen_Height
+const Block_offset = 1
+
 var mat = preload("res://assets/TextureAtlasMaterial.tres")
 var rng = RandomNumberGenerator.new()
 # Make this load from a file
@@ -87,7 +95,7 @@ func generate(w, cx, cz):
 			for z in DIMENSION.z:
 				var b = BlockData.new()
 				var h_noise = (world.height_noise.get_noise_2d(x + cx * DIMENSION.x, z + cz * DIMENSION.z) + 1) / 2.0
-				ground_height[x][z] = int(h_noise * (DIMENSION.y - 1) + 1)
+				ground_height[x][z] = int(h_noise * (Gen_Height - 1) + 1) + Block_offset
 				b.create(generator.generate_surface(ground_height[x][z], x, y, z))
 				_set_block_data(x, y, z, b)
 	


### PR DESCRIPTION
This is a minor change ported from the C# port, essentially limits the terrain gen height to a specific number even when the terrain gen can go higher, was useful when tripling or close to quadrupling the height of chunks. I figured there is literally no performance impact so why not. 

btw when you asked what the performance improvement was I answered but you did not seem to notice it so I will say it here:

It slashes chunk generation time by about 50% from 18.7 or so seconds to ~10 seconds with equivalent configuration settings (the chunk size and the load radius provided by default). Most of the stuttering is gone in-game, the breaking block/(I would assume placing block did not bother implementing yet) stutter is mostly gone though is still slightly there. Memory usage is also decreased ~50%, from 1.5GB to 715MB.