### PR TITLE
Stability fixes and memory optimizations, Also fixes up collision hack

### DIFF
--- a/Chunk.gd
+++ b/Chunk.gd
@@ -138,18 +138,23 @@ func update():
 	mesh_instance.set_mesh(mesh)
 	
 	cst.generate_normals(false)
+	cst.set_material(mat)
 	cst.commit(cmesh)
 	cmesh_instance.set_mesh(cmesh)
-	# This is for collision only and so we do not need to see it (it causes issues with transparent blocks)
-	cmesh_instance.visible = false
+	
+	# Create Collison
+	mesh_instance.create_trimesh_collision()
 	
 	# If it already has a mesh instance child, remove it
 	for child in get_children():
 		if child is MeshInstance:
 			child.queue_free()
-	add_child(mesh_instance)
-	add_child(cmesh_instance)
-	cmesh_instance.create_trimesh_collision()
+			
+	call_deferred("add_child", mesh_instance)
+	call_deferred("add_child",cmesh_instance)
+
+	cst.clear()
+	st.clear()
 
 func _create_block(check, x, y, z, no_collision):
 	var block = _block_data[x][y][z].type
@@ -190,13 +195,13 @@ func create_face(i, x, y, z, texture_atlas_offset, no_collision):
 	var uv_c = Vector2(1.0/texture_atlas_size.x, 1.0/texture_atlas_size.y) + uv_offset
 	var uv_d = Vector2(1.0/texture_atlas_size.x, 0) + uv_offset
 	
-	# Add UVs and tris
-	st.add_triangle_fan(([a, b, c]), ([uv_a, uv_b, uv_c]))
-	st.add_triangle_fan(([a, c, d]), ([uv_a, uv_c, uv_d]))
-	
-	if no_collision:
+	if no_collision == false:
 		cst.add_triangle_fan(([a, b, c]), ([uv_a, uv_b, uv_c]))
 		cst.add_triangle_fan(([a, c, d]), ([uv_a, uv_c, uv_d]))
+	else:
+		# Add UVs and tris
+		st.add_triangle_fan(([a, b, c]), ([uv_a, uv_b, uv_c]))
+		st.add_triangle_fan(([a, c, d]), ([uv_a, uv_c, uv_d]))
 	
 
 func check_transparent_neighbours(x, y, z):

--- a/ProcWorld.gd
+++ b/ProcWorld.gd
@@ -94,10 +94,8 @@ func _load_chunk(cx, cz):
 		var c = Chunk.new()
 		c.generate(self, cx, cz)
 		c.update()
-		add_child(c)
-		chunk_mutex.lock()
+		call_deferred("add_child", c)
 		_loaded_chunks[c_pos] = c
-		chunk_mutex.unlock()
 	return c_pos
 
 func _update_chunk(cx, cz):
@@ -113,19 +111,14 @@ func enforce_render_distance(current_chunk_pos):
 	for v in _loaded_chunks.keys():
 		# Anywhere you directly interface with chunks outside of unloading
 		if abs(v.x - current_chunk_pos.x) > load_radius or abs(v.y - current_chunk_pos.y) > load_radius:
-			chunk_mutex.lock()
-			_loaded_chunks[v].free()
-			_loaded_chunks.erase(v)
-			chunk_mutex.unlock()
+			_unload_chunk(v.x, v.y)
 
 
 func _unload_chunk(cx, cz):
 	var c_pos = Vector2(cx, cz)
 	if _loaded_chunks.has(c_pos):
-		chunk_mutex.lock()
 		_loaded_chunks[c_pos].free()
 		_loaded_chunks.erase(c_pos)
-		chunk_mutex.unlock()
 		# Leaving this here because it is funny as hell
 		# Force it to just fucking chill after holy shit
 		# OS.delay_msec(50)

--- a/project.godot
+++ b/project.godot
@@ -22,7 +22,7 @@ _global_script_class_icons={
 
 config/name="Minecraft Clone"
 run/main_scene="res://Spatial.tscn"
-config/icon="res://icon.png"
+config/icon="res://Resources/icon.png"
 
 [importer_defaults]
 
@@ -100,6 +100,11 @@ scroll_down={
  ]
 }
 
-[rendering]
+[layer_names]
 
-environment/default_environment="res://default_env.tres"
+3d_physics/layer_4="Blocks"
+3d_physics/Blocks=false
+
+[mono]
+
+profiler/enabled=true


### PR DESCRIPTION
This is the first in a wave of a few features and reworks, backported from the C# port. The main features/improvements being:

Clearing out the SurfaceTool arrays when we are done with them, freeing, more usable memory at least on C# (I was able to run a 64x64 grid of 16x255x16 chunks on 5GB of ram, previously took close to 11GB, that is on C# so you can look at how well the before and after is regarding this commit)

Proper threading when dealing with the Scene tree in most areas, except for the removal of chunks due to the performance impact being thread-safe has on it. I will look for a solution to that problem at a later date. At this time it is stable enough to not notice when walking around for minutes on end so I am calling it at the moment. Using call_deferred free or queue free causes huge lag spikes, honestly, chunk reuse would be your best friend, reusing the same chunk nodes over and over and just regenerating them using the teleported coordinates would be way cheaper.

Finally, removal of the hack used in the previous collision setup will be more useful down the line when dealing with the bug regarding being unable to break blocks without collision (No I did not fix that)